### PR TITLE
Add MMA stage-two training script

### DIFF
--- a/musk/contrastive_pretrain.py
+++ b/musk/contrastive_pretrain.py
@@ -1,0 +1,334 @@
+"""Stage-two contrastive pretraining for MUSK.
+
+This script aligns image and text modalities using a CLIP-style
+contrastive loss with an auxiliary masked language modeling (MLM) loss
+via a lightweight cross-attention decoder. It supports either
+WebDataset shards or a JSON lines file containing paired image paths
+and text captions. Use ``accelerate launch`` for multi-GPU training.
+
+Example using WebDataset shards:
+    accelerate launch --mixed_precision fp16 -m musk.contrastive_pretrain \
+        --pair-data /path/to/pairs/{0000..0100}.tar \
+        --batch-size 16 --epochs 20 --output musk_stage2.pt
+
+Example using a JSON lines file:
+    accelerate launch --mixed_precision fp16 -m musk.contrastive_pretrain \
+        --json-data pairs.jsonl \
+        --batch-size 16 --epochs 20 --output musk_stage2.pt
+
+When ``--json-data`` is supplied, the loader reserves 10% of the pairs for
+validation and both contrastive and MLM losses are reported on the validation
+split each epoch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision
+from torch.utils.data import DataLoader
+import webdataset as wds
+from timm.models import create_model
+from transformers import XLMRobertaTokenizer
+from accelerate import Accelerator
+from accelerate.utils import DistributedDataParallelKwargs
+import wandb
+
+from .json_dataset import ImageTextJsonDataset
+from .utils import xlm_tokenizer
+from . import modeling  # register MUSK models
+
+
+def get_pair_loader(urls: str, tokenizer: XLMRobertaTokenizer, batch_size: int, num_workers: int) -> DataLoader:
+    transform = torchvision.transforms.Compose([
+        torchvision.transforms.Resize(384, interpolation=3, antialias=True),
+        torchvision.transforms.CenterCrop((384, 384)),
+        torchvision.transforms.ToTensor(),
+    ])
+
+    def preprocess(img, txt):
+        tokens, pad = xlm_tokenizer(txt.strip(), tokenizer)
+        return (
+            transform(img.convert("RGB")),
+            torch.tensor(tokens),
+            torch.tensor(pad, dtype=torch.bool),
+        )
+
+    dataset = (
+        wds.WebDataset(urls)
+        .decode("pil")
+        .to_tuple("jpg;png", "txt")
+        .map(lambda img, txt: preprocess(img, txt))
+    )
+    return DataLoader(dataset.batched(batch_size), num_workers=num_workers)
+
+
+def get_json_pair_loader(json_file: str, tokenizer: XLMRobertaTokenizer, batch_size: int, num_workers: int) -> DataLoader:
+    dataset = ImageTextJsonDataset(json_file, mode="pair", tokenizer=tokenizer)
+    return DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, shuffle=True)
+
+
+def get_json_pair_loaders(
+    json_file: str,
+    tokenizer: XLMRobertaTokenizer,
+    batch_size: int,
+    num_workers: int,
+    val_split: float = 0.1,
+) -> tuple[DataLoader, DataLoader]:
+    dataset = ImageTextJsonDataset(json_file, mode="pair", tokenizer=tokenizer)
+    n_val = max(1, int(len(dataset) * val_split))
+    n_train = len(dataset) - n_val
+    train_set, val_set = torch.utils.data.random_split(dataset, [n_train, n_val])
+    train_loader = DataLoader(train_set, batch_size=batch_size, num_workers=num_workers, shuffle=True)
+    val_loader = DataLoader(val_set, batch_size=batch_size, num_workers=num_workers)
+    return train_loader, val_loader
+
+
+def random_mask(shape, ratio, device):
+    return torch.rand(shape, device=device) < ratio
+
+
+class CrossAttentionDecoder(nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int = 8):
+        super().__init__()
+        layer = nn.TransformerDecoderLayer(d_model=embed_dim, nhead=num_heads, batch_first=True)
+        self.decoder = nn.TransformerDecoder(layer, num_layers=1)
+
+    def forward(self, text: torch.Tensor, image: torch.Tensor, text_mask: torch.Tensor | None = None):
+        return self.decoder(tgt=text, memory=image, tgt_key_padding_mask=text_mask)
+
+
+def clip_loss(image_emb: torch.Tensor, text_emb: torch.Tensor, logit_scale: torch.Tensor) -> torch.Tensor:
+    logits_per_image = logit_scale * image_emb @ text_emb.t()
+    labels = torch.arange(image_emb.size(0), device=image_emb.device)
+    loss_i = F.cross_entropy(logits_per_image, labels)
+    loss_t = F.cross_entropy(logits_per_image.t(), labels)
+    return (loss_i + loss_t) / 2
+
+
+def get_args():
+    p = argparse.ArgumentParser(description="Stage-two contrastive pretraining")
+    p.add_argument("--pair-data", type=str, help="WebDataset pattern with paired image-text shards")
+    p.add_argument("--json-data", type=str, help="JSON lines file with paired samples")
+    p.add_argument("--epochs", type=int, default=20)
+    # large batches can easily exceed GPU memory when training the
+    # 384x384 MUSK model; use a conservative default
+    p.add_argument("--batch-size", type=int, default=16)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--mask-ratio", type=float, default=0.3)
+    p.add_argument("--output", type=str, default="musk_stage2.pt")
+    p.add_argument(
+        "--wandb-project",
+        type=str,
+        default=None,
+        help="Optional Weights & Biases project for logging",
+    )
+    p.add_argument(
+        "--encoder",
+        type=str,
+        default=None,
+        help="Path to encoder weights pretrained in stage one",
+    )
+    p.add_argument("--num-workers", type=int, default=4)
+    return p.parse_args()
+
+
+def main():
+    args = get_args()
+    # ``find_unused_parameters`` avoids reduction errors when some parameters
+    # are used only in the auxiliary MLM path
+    ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
+    accelerator = Accelerator(kwargs_handlers=[ddp_kwargs])
+    run = None
+    if args.wandb_project and accelerator.is_main_process:
+        run = wandb.init(project=args.wandb_project)
+
+    if not args.json_data and not args.pair_data:
+        raise ValueError("Provide --json-data or --pair-data")
+
+    tokenizer_path = Path(__file__).resolve().parent / "models" / "tokenizer.spm"
+    tokenizer = XLMRobertaTokenizer(str(tokenizer_path))
+    mask_token_id = tokenizer.convert_tokens_to_ids("<mask>")
+
+    if args.json_data:
+        (
+            pair_loader,
+            val_loader,
+        ) = get_json_pair_loaders(
+            args.json_data,
+            tokenizer,
+            args.batch_size,
+            args.num_workers,
+        )
+    else:
+        pair_loader = get_pair_loader(args.pair_data, tokenizer, args.batch_size, args.num_workers)
+        val_loader = None
+
+    model = create_model("musk_large_patch16_384")
+    if args.encoder:
+        state = torch.load(args.encoder, map_location="cpu")
+        missing = model.beit3.load_state_dict(state, strict=False)
+        accelerator.print(f"Loaded encoder weights from {args.encoder}")
+        if missing.missing_keys:
+            accelerator.print(f"Missing keys in encoder load: {missing.missing_keys}")
+    embed_dim = model.beit3.args.encoder_embed_dim
+    decoder = CrossAttentionDecoder(embed_dim)
+    mlm_head = nn.Linear(embed_dim, len(tokenizer))
+
+    optimizer = torch.optim.AdamW(
+        itertools.chain(model.parameters(), decoder.parameters(), mlm_head.parameters()),
+        lr=args.lr,
+        betas=(0.9, 0.95),
+        weight_decay=0.05,
+    )
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs * len(pair_loader))
+
+    components = accelerator.prepare(model, decoder, mlm_head, optimizer, scheduler, pair_loader)
+    model, decoder, mlm_head, optimizer, scheduler, pair_loader = components
+    if val_loader is not None:
+        val_loader = accelerator.prepare(val_loader)
+    base_model = accelerator.unwrap_model(model)
+
+    ce_loss = nn.CrossEntropyLoss()
+
+    model.train()
+    for epoch in range(args.epochs):
+        loss_epoch = 0.0
+        mlm_epoch = 0.0
+        num_batches = 0
+        for images, tokens, padding in pair_loader:
+            optimizer.zero_grad()
+            images = images.to(accelerator.device)
+            tokens = tokens.to(accelerator.device)
+            padding = padding.to(accelerator.device)
+
+            # ----- Contrastive path -----
+            with accelerator.no_sync(model):
+                img_emb, txt_emb = model(
+                    image=images,
+                    text_description=tokens,
+                    padding_mask=padding,
+                    return_global=True,
+                )
+                logit_scale = base_model.logit_scale.exp()
+                loss_c = clip_loss(img_emb, txt_emb, logit_scale)
+                accelerator.backward(loss_c)
+
+            # ----- Auxiliary MLM -----
+            mask_txt = random_mask(tokens.shape, args.mask_ratio, tokens.device) & (~padding)
+            inp_tokens = tokens.clone()
+            inp_tokens[mask_txt] = mask_token_id
+
+            _, _, img_seq, txt_seq = model(
+                image=images,
+                text_description=inp_tokens,
+                padding_mask=padding,
+                with_head=False,
+                out_norm=False,
+                return_global=False,
+                return_seq=True,
+            )
+            dec_out = decoder(txt_seq, img_seq, padding.bool())
+            pred = mlm_head(dec_out[mask_txt])
+            loss_mlm = ce_loss(pred, tokens[mask_txt])
+
+            accelerator.backward(loss_mlm)
+            optimizer.step()
+            scheduler.step()
+
+            loss_epoch += loss_c.item()
+            mlm_epoch += loss_mlm.item()
+            num_batches += 1
+
+        denom = accelerator.reduce(torch.tensor(num_batches, device=accelerator.device), reduction="sum")
+        contrast_total = accelerator.reduce(torch.tensor(loss_epoch, device=accelerator.device), reduction="sum")
+        mlm_total = accelerator.reduce(torch.tensor(mlm_epoch, device=accelerator.device), reduction="sum")
+
+        c_avg = (contrast_total / denom).item()
+        mlm_avg = (mlm_total / denom).item()
+
+        if val_loader is not None:
+            val_c = 0.0
+            val_mlm = 0.0
+            val_batches = 0
+            for images, tokens, padding in val_loader:
+                images = images.to(accelerator.device)
+                tokens = tokens.to(accelerator.device)
+                padding = padding.to(accelerator.device)
+
+                with torch.no_grad():
+                    img_emb, txt_emb = model(
+                        image=images,
+                        text_description=tokens,
+                        padding_mask=padding,
+                        return_global=True,
+                    )
+                logit_scale = base_model.logit_scale.exp()
+                loss_c = clip_loss(img_emb, txt_emb, logit_scale)
+
+                mask_txt = random_mask(tokens.shape, args.mask_ratio, tokens.device) & (~padding)
+                inp_tokens = tokens.clone()
+                inp_tokens[mask_txt] = mask_token_id
+                with torch.no_grad():
+                    _, _, img_seq, txt_seq = model(
+                        image=images,
+                        text_description=inp_tokens,
+                        padding_mask=padding,
+                        with_head=False,
+                        out_norm=False,
+                        return_global=False,
+                        return_seq=True,
+                    )
+                    dec_out = decoder(txt_seq, img_seq, padding.bool())
+                    pred = mlm_head(dec_out[mask_txt])
+                    loss_mlm = ce_loss(pred, tokens[mask_txt])
+
+                val_c += loss_c.item()
+                val_mlm += loss_mlm.item()
+                val_batches += 1
+
+            val_denom = accelerator.reduce(torch.tensor(val_batches, device=accelerator.device), reduction="sum")
+            val_c_total = accelerator.reduce(torch.tensor(val_c, device=accelerator.device), reduction="sum")
+            val_mlm_total = accelerator.reduce(torch.tensor(val_mlm, device=accelerator.device), reduction="sum")
+            c_val_avg = (val_c_total / val_denom).item()
+            mlm_val_avg = (val_mlm_total / val_denom).item()
+            accelerator.print(
+                f"Epoch {epoch + 1}: Contrastive={c_avg:.4f} MLM={mlm_avg:.4f} Val_Contrastive={c_val_avg:.4f} Val_MLM={mlm_val_avg:.4f}"
+            )
+            if run:
+                run.log(
+                    {
+                        "epoch": epoch + 1,
+                        "train_contrastive": c_avg,
+                        "train_mlm": mlm_avg,
+                        "val_contrastive": c_val_avg,
+                        "val_mlm": mlm_val_avg,
+                    }
+                )
+        else:
+            accelerator.print(
+                f"Epoch {epoch + 1}: Contrastive={c_avg:.4f} MLM={mlm_avg:.4f}"
+            )
+            if run:
+                run.log(
+                    {
+                        "epoch": epoch + 1,
+                        "train_contrastive": c_avg,
+                        "train_mlm": mlm_avg,
+                    }
+                )
+
+    if accelerator.is_main_process:
+        accelerator.print(f"Saving model to {args.output}")
+        torch.save(base_model.state_dict(), args.output)
+        if run:
+            run.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/musk/json_dataset.py
+++ b/musk/json_dataset.py
@@ -1,0 +1,108 @@
+"""Dataset utilities for loading image and text samples from a JSON file.
+
+Each line in the JSON file should be an object with two keys:
+```
+{"image": "/path/to/image.jpg", "text": "free form caption"}
+```
+
+Use ``mode="image"`` to iterate over images only, ``mode="text"`` for text
+only, or ``mode="pair"`` to return ``(image, text)`` tuples.
+"""
+
+import json
+from typing import List, Tuple
+
+import torch
+from torch.utils.data import Dataset, DataLoader
+from PIL import Image
+import torchvision
+
+from transformers import PreTrainedTokenizer
+from .utils import xlm_tokenizer
+
+
+def _load_json_lines(path: str) -> List[dict]:
+    items = []
+    with open(path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            items.append(json.loads(line))
+    return items
+
+
+class ImageTextJsonDataset(Dataset):
+    """Dataset reading samples from a JSON lines file."""
+
+    def __init__(
+        self,
+        json_file: str,
+        mode: str = "image",
+        transform: torchvision.transforms.Compose | None = None,
+        tokenizer: PreTrainedTokenizer | None = None,
+    ) -> None:
+        assert mode in {"image", "text", "pair"}
+        self.items = _load_json_lines(json_file)
+        self.mode = mode
+        self.transform = transform or torchvision.transforms.Compose(
+            [
+                torchvision.transforms.Resize(384, interpolation=3, antialias=True),
+                torchvision.transforms.CenterCrop((384, 384)),
+                torchvision.transforms.ToTensor(),
+            ]
+        )
+        self.tokenizer = tokenizer
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self.items)
+
+    def _load_image(self, path: str) -> torch.Tensor:
+        img = Image.open(path).convert("RGB")
+        return self.transform(img)
+
+    def _load_text(self, text: str) -> Tuple[torch.Tensor, torch.Tensor]:
+        assert self.tokenizer is not None, "Tokenizer required for text mode"
+        tokens, pad = xlm_tokenizer(text.strip(), self.tokenizer)
+        return torch.tensor(tokens), torch.tensor(pad, dtype=torch.bool)
+
+    def __getitem__(self, idx: int):  # type: ignore[override]
+        item = self.items[idx]
+        image_path = item.get("image")
+        caption = item.get("text")
+
+        if self.mode == "image":
+            return self._load_image(image_path)
+        if self.mode == "text":
+            return self._load_text(caption)
+
+        return (self._load_image(image_path),) + self._load_text(caption)
+
+
+def get_json_loader(
+    json_file: str,
+    mode: str,
+    batch_size: int,
+    num_workers: int,
+    tokenizer: PreTrainedTokenizer | None = None,
+) -> DataLoader:
+    dataset = ImageTextJsonDataset(json_file, mode=mode, tokenizer=tokenizer)
+    return DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, shuffle=True)
+
+
+def get_json_loaders(
+    json_file: str,
+    mode: str,
+    batch_size: int,
+    num_workers: int,
+    tokenizer: PreTrainedTokenizer | None = None,
+    val_split: float = 0.1,
+) -> tuple[DataLoader, DataLoader]:
+    """Return training and validation loaders split from a JSON lines dataset."""
+    dataset = ImageTextJsonDataset(json_file, mode=mode, tokenizer=tokenizer)
+    n_val = max(1, int(len(dataset) * val_split))
+    n_train = len(dataset) - n_val
+    train_set, val_set = torch.utils.data.random_split(dataset, [n_train, n_val])
+    train_loader = DataLoader(train_set, batch_size=batch_size, num_workers=num_workers, shuffle=True)
+    val_loader = DataLoader(val_set, batch_size=batch_size, num_workers=num_workers)
+    return train_loader, val_loader

--- a/musk/mma_stage2.py
+++ b/musk/mma_stage2.py
@@ -1,0 +1,242 @@
+"""Stage-two MMA pretraining for MUSK.
+
+This script trains MUSK using contrastive loss with an auxiliary
+cross-attention decoder for masked language modeling (MMA).
+It mirrors ``musk.contrastive_pretrain`` but is provided as an
+independent example. Use ``accelerate launch`` to run on multiple GPUs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision
+from torch.utils.data import DataLoader
+import webdataset as wds
+from timm.models import create_model
+from transformers import XLMRobertaTokenizer
+from accelerate import Accelerator
+from accelerate.utils import DistributedDataParallelKwargs
+
+from .json_dataset import ImageTextJsonDataset
+from .utils import xlm_tokenizer
+from . import modeling  # register MUSK models
+
+
+def get_pair_loader(urls: str, tokenizer: XLMRobertaTokenizer, batch_size: int, num_workers: int) -> DataLoader:
+    transform = torchvision.transforms.Compose([
+        torchvision.transforms.Resize(384, interpolation=3, antialias=True),
+        torchvision.transforms.CenterCrop((384, 384)),
+        torchvision.transforms.ToTensor(),
+    ])
+
+    def preprocess(img, txt):
+        tokens, pad = xlm_tokenizer(txt.strip(), tokenizer)
+        return (
+            transform(img.convert("RGB")),
+            torch.tensor(tokens),
+            torch.tensor(pad, dtype=torch.bool),
+        )
+
+    dataset = (
+        wds.WebDataset(urls)
+        .decode("pil")
+        .to_tuple("jpg;png", "txt")
+        .map(lambda img, txt: preprocess(img, txt))
+    )
+    return DataLoader(dataset.batched(batch_size), num_workers=num_workers)
+
+
+def get_json_loaders(json_file: str, tokenizer: XLMRobertaTokenizer, batch_size: int, num_workers: int, val_split: float = 0.1) -> tuple[DataLoader, DataLoader]:
+    dataset = ImageTextJsonDataset(json_file, mode="pair", tokenizer=tokenizer)
+    n_val = max(1, int(len(dataset) * val_split))
+    n_train = len(dataset) - n_val
+    train_set, val_set = torch.utils.data.random_split(dataset, [n_train, n_val])
+    train_loader = DataLoader(train_set, batch_size=batch_size, num_workers=num_workers, shuffle=True)
+    val_loader = DataLoader(val_set, batch_size=batch_size, num_workers=num_workers)
+    return train_loader, val_loader
+
+
+def random_mask(shape, ratio, device):
+    return torch.rand(shape, device=device) < ratio
+
+
+class CrossAttentionDecoder(nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int = 8):
+        super().__init__()
+        layer = nn.TransformerDecoderLayer(d_model=embed_dim, nhead=num_heads, batch_first=True)
+        self.decoder = nn.TransformerDecoder(layer, num_layers=1)
+
+    def forward(self, text: torch.Tensor, image: torch.Tensor, text_mask: torch.Tensor | None = None):
+        return self.decoder(tgt=text, memory=image, tgt_key_padding_mask=text_mask)
+
+
+def clip_loss(image_emb: torch.Tensor, text_emb: torch.Tensor, logit_scale: torch.Tensor) -> torch.Tensor:
+    logits = logit_scale * image_emb @ text_emb.t()
+    targets = torch.arange(image_emb.size(0), device=image_emb.device)
+    loss_i = F.cross_entropy(logits, targets)
+    loss_t = F.cross_entropy(logits.t(), targets)
+    return (loss_i + loss_t) / 2
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Stage-two MMA pretraining")
+    p.add_argument("--pair-data", type=str, help="WebDataset pattern of image-text pairs")
+    p.add_argument("--json-data", type=str, help="JSON lines file with paired samples")
+    p.add_argument("--epochs", type=int, default=20)
+    p.add_argument("--batch-size", type=int, default=16)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--mask-ratio", type=float, default=0.3)
+    p.add_argument("--output", type=str, default="musk_stage2_mma.pt")
+    p.add_argument("--num-workers", type=int, default=4)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    ddp = DistributedDataParallelKwargs(find_unused_parameters=True)
+    accelerator = Accelerator(kwargs_handlers=[ddp])
+
+    if not args.json_data and not args.pair_data:
+        raise ValueError("Provide --json-data or --pair-data")
+
+    tokenizer_path = Path(__file__).resolve().parent / "models" / "tokenizer.spm"
+    tokenizer = XLMRobertaTokenizer(str(tokenizer_path))
+    mask_token_id = tokenizer.convert_tokens_to_ids("<mask>")
+
+    if args.json_data:
+        train_loader, val_loader = get_json_loaders(
+            args.json_data, tokenizer, args.batch_size, args.num_workers
+        )
+    else:
+        train_loader = get_pair_loader(args.pair_data, tokenizer, args.batch_size, args.num_workers)
+        val_loader = None
+
+    model = create_model("musk_large_patch16_384")
+    embed_dim = model.beit3.args.encoder_embed_dim
+    decoder = CrossAttentionDecoder(embed_dim)
+    mlm_head = nn.Linear(embed_dim, len(tokenizer))
+
+    optimizer = torch.optim.AdamW(
+        itertools.chain(model.parameters(), decoder.parameters(), mlm_head.parameters()),
+        lr=args.lr,
+        betas=(0.9, 0.95),
+        weight_decay=0.05,
+    )
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs * len(train_loader))
+
+    components = accelerator.prepare(model, decoder, mlm_head, optimizer, scheduler, train_loader)
+    model, decoder, mlm_head, optimizer, scheduler, train_loader = components
+    if val_loader is not None:
+        val_loader = accelerator.prepare(val_loader)
+    base_model = accelerator.unwrap_model(model)
+
+    ce_loss = nn.CrossEntropyLoss()
+
+    for epoch in range(args.epochs):
+        model.train()
+        lc, lm = 0.0, 0.0
+        n = 0
+        for images, tokens, padding in train_loader:
+            optimizer.zero_grad()
+            images = images.to(accelerator.device)
+            tokens = tokens.to(accelerator.device)
+            padding = padding.to(accelerator.device)
+
+            with accelerator.no_sync(model):
+                img_emb, txt_emb = model(
+                    image=images,
+                    text_description=tokens,
+                    padding_mask=padding,
+                    return_global=True,
+                )
+                loss_c = clip_loss(img_emb, txt_emb, base_model.logit_scale.exp())
+                accelerator.backward(loss_c)
+
+            mask_txt = random_mask(tokens.shape, args.mask_ratio, tokens.device) & (~padding)
+            inp = tokens.clone()
+            inp[mask_txt] = mask_token_id
+
+            _, _, img_seq, txt_seq = model(
+                image=images,
+                text_description=inp,
+                padding_mask=padding,
+                with_head=False,
+                out_norm=False,
+                return_global=False,
+                return_seq=True,
+            )
+            dec_out = decoder(txt_seq, img_seq, padding.bool())
+            pred = mlm_head(dec_out[mask_txt])
+            loss_mlm = ce_loss(pred, tokens[mask_txt])
+
+            accelerator.backward(loss_mlm)
+            optimizer.step()
+            scheduler.step()
+
+            lc += loss_c.item()
+            lm += loss_mlm.item()
+            n += 1
+
+        lc_total = accelerator.reduce(torch.tensor(lc, device=accelerator.device), reduction="sum")
+        lm_total = accelerator.reduce(torch.tensor(lm, device=accelerator.device), reduction="sum")
+        n_total = accelerator.reduce(torch.tensor(n, device=accelerator.device), reduction="sum")
+        accelerator.print(f"Epoch {epoch + 1}: Contrastive={(lc_total/n_total).item():.4f} MLM={(lm_total/n_total).item():.4f}")
+
+        if val_loader is not None:
+            vc, vm = 0.0, 0.0
+            vn = 0
+            model.eval()
+            for images, tokens, padding in val_loader:
+                images = images.to(accelerator.device)
+                tokens = tokens.to(accelerator.device)
+                padding = padding.to(accelerator.device)
+                with torch.no_grad():
+                    img_emb, txt_emb = model(
+                        image=images,
+                        text_description=tokens,
+                        padding_mask=padding,
+                        return_global=True,
+                    )
+                loss_c = clip_loss(img_emb, txt_emb, base_model.logit_scale.exp())
+
+                mask_txt = random_mask(tokens.shape, args.mask_ratio, tokens.device) & (~padding)
+                inp = tokens.clone()
+                inp[mask_txt] = mask_token_id
+                with torch.no_grad():
+                    _, _, img_seq, txt_seq = model(
+                        image=images,
+                        text_description=inp,
+                        padding_mask=padding,
+                        with_head=False,
+                        out_norm=False,
+                        return_global=False,
+                        return_seq=True,
+                    )
+                    dec_out = decoder(txt_seq, img_seq, padding.bool())
+                    pred = mlm_head(dec_out[mask_txt])
+                    loss_mlm = ce_loss(pred, tokens[mask_txt])
+
+                vc += loss_c.item()
+                vm += loss_mlm.item()
+                vn += 1
+
+            vc_t = accelerator.reduce(torch.tensor(vc, device=accelerator.device), reduction="sum")
+            vm_t = accelerator.reduce(torch.tensor(vm, device=accelerator.device), reduction="sum")
+            vn_t = accelerator.reduce(torch.tensor(vn, device=accelerator.device), reduction="sum")
+            accelerator.print(
+                f"Epoch {epoch + 1}: Val_Contrastive={(vc_t/vn_t).item():.4f} Val_MLM={(vm_t/vn_t).item():.4f}"
+            )
+
+    if accelerator.is_main_process:
+        accelerator.print(f"Saving model to {args.output}")
+        torch.save(base_model.state_dict(), args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/musk/pretrain.py
+++ b/musk/pretrain.py
@@ -1,0 +1,304 @@
+"""Pretraining script for MUSK using unified masked modeling.
+
+This example demonstrates stage-one training on **unpaired** image and text
+collections. Images and texts are loaded independently and the model is
+optimized with masked image modeling (MIM) and masked language modeling (MLM)
+losses.
+
+Example using WebDataset shards:
+    accelerate launch -m musk.pretrain \
+        --image-data /path/to/images/{0000..0100}.tar \
+        --text-data /path/to/texts/{0000..0100}.tar \
+        --epochs 5 --output musk_pretrained.pt
+
+Example using a local JSON lines file:
+    accelerate launch -m musk.pretrain \
+        --json-data /path/to/data.jsonl \
+        --epochs 5 --output musk_pretrained.pt
+
+When a JSON file is provided, 10% of the samples are automatically used for
+validation and the script reports MIM and MLM losses on the validation split.
+"""
+
+import argparse
+import itertools
+from pathlib import Path
+import wandb
+
+import torch
+import torch.nn.functional as F
+import torchvision
+from torch.utils.data import DataLoader
+import webdataset as wds
+from .json_dataset import get_json_loader, get_json_loaders
+from timm.models import create_model
+from accelerate import Accelerator
+from accelerate.utils import DistributedDataParallelKwargs
+from transformers import XLMRobertaTokenizer
+from .utils import xlm_tokenizer
+from . import modeling  # ensure custom models are registered
+
+
+def get_image_loader(urls, batch_size, num_workers):
+    transform = torchvision.transforms.Compose([
+        torchvision.transforms.Resize(384, interpolation=3, antialias=True),
+        torchvision.transforms.CenterCrop((384, 384)),
+        torchvision.transforms.ToTensor(),
+    ])
+
+    def preprocess(img):
+        return transform(img.convert("RGB"))
+
+    dataset = wds.WebDataset(urls).decode("pil").to_tuple("jpg;png").map(preprocess)
+    return DataLoader(dataset.batched(batch_size), num_workers=num_workers)
+
+
+def get_text_loader(urls, tokenizer, batch_size, num_workers):
+    def preprocess(txt):
+        tokens, pad = xlm_tokenizer(txt.strip(), tokenizer)
+        return torch.tensor(tokens), torch.tensor(pad, dtype=torch.bool)
+
+    dataset = wds.WebDataset(urls).to_tuple("txt").map(lambda x: preprocess(x[0]))
+    return DataLoader(dataset.batched(batch_size), num_workers=num_workers)
+
+
+def random_mask(shape, ratio, device):
+    return (torch.rand(shape, device=device) < ratio)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="MUSK masked-modeling pretraining")
+    parser.add_argument("--image-data", type=str, help="WebDataset pattern for image shards")
+    parser.add_argument("--text-data", type=str, help="WebDataset pattern for text shards")
+    parser.add_argument("--json-data", type=str, help="JSON lines file with 'image' and 'text' fields")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--lr", type=float, default=3e-4)
+    parser.add_argument("--mask-ratio", type=float, default=0.15)
+    parser.add_argument("--output", type=str, default="musk.pt")
+    parser.add_argument(
+        "--wandb-project",
+        type=str,
+        default=None,
+        help="Optional Weights & Biases project for logging",
+    )
+    parser.add_argument(
+        "--encoder-out",
+        type=str,
+        default=None,
+        help="Optional path to save only the encoder weights for stage-two training",
+    )
+    parser.add_argument("--num-workers", type=int, default=4)
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+    # ``find_unused_parameters`` allows DDP to handle parameters that are only
+    # involved in one of the two masked modeling losses
+    ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
+    accelerator = Accelerator(kwargs_handlers=[ddp_kwargs])
+    run = None
+    if args.wandb_project and accelerator.is_main_process:
+        run = wandb.init(project=args.wandb_project)
+
+    if not args.json_data and not (args.image_data and args.text_data):
+        raise ValueError("Provide --json-data or both --image-data and --text-data")
+
+    tokenizer_path = Path(__file__).resolve().parent / "models" / "tokenizer.spm"
+    tokenizer = XLMRobertaTokenizer(str(tokenizer_path))
+    mask_token_id = tokenizer.convert_tokens_to_ids("<mask>")
+
+    if args.json_data:
+        (
+            image_loader,
+            val_image_loader,
+        ) = get_json_loaders(
+            args.json_data,
+            mode="image",
+            batch_size=args.batch_size,
+            num_workers=args.num_workers,
+            tokenizer=None,
+        )
+        (
+            text_loader,
+            val_text_loader,
+        ) = get_json_loaders(
+            args.json_data,
+            mode="text",
+            batch_size=args.batch_size,
+            num_workers=args.num_workers,
+            tokenizer=tokenizer,
+        )
+    else:
+        image_loader = get_image_loader(args.image_data, args.batch_size, args.num_workers)
+        text_loader = get_text_loader(args.text_data, tokenizer, args.batch_size, args.num_workers)
+        val_image_loader = None
+        val_text_loader = None
+
+    model = create_model("musk_large_patch16_384")
+    unwrapped = accelerator.unwrap_model(model)
+    embed_dim = unwrapped.beit3.args.encoder_embed_dim
+    patch_size = unwrapped.beit3.args.patch_size
+    img_decoder = torch.nn.Linear(embed_dim, 3 * patch_size * patch_size)
+    txt_decoder = torch.nn.Linear(embed_dim, len(tokenizer))
+
+    optimizer = torch.optim.AdamW(
+        itertools.chain(model.parameters(), img_decoder.parameters(), txt_decoder.parameters()),
+        lr=args.lr,
+    )
+
+    components = accelerator.prepare(
+        model, img_decoder, txt_decoder, optimizer, image_loader, text_loader
+    )
+    model, img_decoder, txt_decoder, optimizer, image_loader, text_loader = components
+    if val_image_loader is not None:
+        val_image_loader = accelerator.prepare(val_image_loader)
+        val_text_loader = accelerator.prepare(val_text_loader)
+
+    mse_loss = torch.nn.MSELoss()
+    ce_loss = torch.nn.CrossEntropyLoss()
+
+    model.train()
+    for epoch in range(args.epochs):
+        mim_loss_epoch = 0.0
+        mlm_loss_epoch = 0.0
+        num_batches = 0
+        for images, (tokens, padding) in zip(image_loader, text_loader):
+            optimizer.zero_grad()
+
+            # ----- Masked Image Modeling -----
+            B, _, H, W = images.shape
+            num_patches = (H // patch_size) * (W // patch_size)
+            mask_img = random_mask((B, num_patches), args.mask_ratio, images.device)
+            with accelerator.no_sync(model):
+                _, _, img_seq, _ = model(
+                    image=images,
+                    vision_mask=mask_img,
+                    with_head=False,
+                    out_norm=False,
+                    return_global=False,
+                    return_seq=True,
+                )
+                patches = F.unfold(images, kernel_size=patch_size, stride=patch_size).transpose(1, 2)
+                target = patches[mask_img]
+                pred = img_decoder(img_seq[mask_img])
+                loss_img = mse_loss(pred, target)
+                accelerator.backward(loss_img)
+
+            # ----- Masked Language Modeling -----
+            tokens = tokens.to(images.device)
+            padding = padding.to(images.device)
+            mask_txt = random_mask(tokens.shape, args.mask_ratio, tokens.device) & (~padding)
+            inp_tokens = tokens.clone()
+            inp_tokens[mask_txt] = mask_token_id
+            _, _, _, txt_seq = model(
+                text_description=inp_tokens,
+                padding_mask=padding,
+                with_head=False,
+                out_norm=False,
+                return_global=False,
+                return_seq=True,
+            )
+            pred = txt_decoder(txt_seq[mask_txt])
+            loss_txt = ce_loss(pred, tokens[mask_txt])
+
+            accelerator.backward(loss_txt)
+            optimizer.step()
+
+            mim_loss_epoch += loss_img.item()
+            mlm_loss_epoch += loss_txt.item()
+            num_batches += 1
+
+        denom = accelerator.reduce(torch.tensor(num_batches, device=accelerator.device), reduction="sum")
+        mim_total = accelerator.reduce(torch.tensor(mim_loss_epoch, device=accelerator.device), reduction="sum")
+        mlm_total = accelerator.reduce(torch.tensor(mlm_loss_epoch, device=accelerator.device), reduction="sum")
+
+        mim_avg = (mim_total / denom).item()
+        mlm_avg = (mlm_total / denom).item()
+
+        if val_image_loader is not None:
+            val_mim = 0.0
+            val_mlm = 0.0
+            val_batches = 0
+            for images, (tokens, padding) in zip(val_image_loader, val_text_loader):
+                B, _, H, W = images.shape
+                num_patches = (H // patch_size) * (W // patch_size)
+                mask_img = random_mask((B, num_patches), args.mask_ratio, images.device)
+                with torch.no_grad():
+                    _, _, img_seq, _ = model(
+                        image=images,
+                        vision_mask=mask_img,
+                        with_head=False,
+                        out_norm=False,
+                        return_global=False,
+                        return_seq=True,
+                    )
+                patches = F.unfold(images, kernel_size=patch_size, stride=patch_size).transpose(1, 2)
+                target = patches[mask_img]
+                pred = img_decoder(img_seq[mask_img])
+                loss_img = mse_loss(pred, target)
+
+                tokens = tokens.to(images.device)
+                padding = padding.to(images.device)
+                mask_txt = random_mask(tokens.shape, args.mask_ratio, tokens.device) & (~padding)
+                inp_tokens = tokens.clone()
+                inp_tokens[mask_txt] = mask_token_id
+                with torch.no_grad():
+                    _, _, _, txt_seq = model(
+                        text_description=inp_tokens,
+                        padding_mask=padding,
+                        with_head=False,
+                        out_norm=False,
+                        return_global=False,
+                        return_seq=True,
+                    )
+                pred_txt = txt_decoder(txt_seq[mask_txt])
+                loss_txt = ce_loss(pred_txt, tokens[mask_txt])
+
+                val_mim += loss_img.item()
+                val_mlm += loss_txt.item()
+                val_batches += 1
+
+            val_denom = accelerator.reduce(torch.tensor(val_batches, device=accelerator.device), reduction="sum")
+            val_mim_total = accelerator.reduce(torch.tensor(val_mim, device=accelerator.device), reduction="sum")
+            val_mlm_total = accelerator.reduce(torch.tensor(val_mlm, device=accelerator.device), reduction="sum")
+            mim_val_avg = (val_mim_total / val_denom).item()
+            mlm_val_avg = (val_mlm_total / val_denom).item()
+            accelerator.print(
+                f"Epoch {epoch + 1}: MIM={mim_avg:.4f} MLM={mlm_avg:.4f} Val_MIM={mim_val_avg:.4f} Val_MLM={mlm_val_avg:.4f}"
+            )
+            if run:
+                run.log(
+                    {
+                        "epoch": epoch + 1,
+                        "train_mim": mim_avg,
+                        "train_mlm": mlm_avg,
+                        "val_mim": mim_val_avg,
+                        "val_mlm": mlm_val_avg,
+                    }
+                )
+        else:
+            accelerator.print(f"Epoch {epoch + 1}: MIM={mim_avg:.4f} MLM={mlm_avg:.4f}")
+            if run:
+                run.log(
+                    {
+                        "epoch": epoch + 1,
+                        "train_mim": mim_avg,
+                        "train_mlm": mlm_avg,
+                    }
+                )
+
+    if accelerator.is_main_process:
+        base_model = accelerator.unwrap_model(model)
+        accelerator.print(f"Saving model to {args.output}")
+        torch.save(base_model.state_dict(), args.output)
+        if args.encoder_out:
+            accelerator.print(f"Saving encoder weights to {args.encoder_out}")
+            torch.save(base_model.beit3.state_dict(), args.encoder_out)
+        if run:
+            run.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/musk/pretrain_multigpu.py
+++ b/musk/pretrain_multigpu.py
@@ -1,0 +1,235 @@
+"""Stage-one pretraining script with multi-GPU support.
+
+This script trains the MUSK model using masked image modeling (MIM) and
+masked language modeling (MLM) losses on unpaired datasets. It mirrors the
+behaviour of ``musk.pretrain`` but is provided as a self-contained example that
+leverages HuggingFace Accelerate for distributed training.
+
+Example:
+    accelerate launch -m musk.pretrain_multigpu \
+        --json-data /path/to/data.jsonl \
+        --epochs 5 --output musk_pretrained.pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+import torchvision
+from torch.utils.data import DataLoader
+from accelerate import Accelerator
+from accelerate.utils import DistributedDataParallelKwargs
+from transformers import XLMRobertaTokenizer
+import webdataset as wds
+from timm.models import create_model
+
+from . import modeling  # register custom model
+from .json_dataset import get_json_loaders, get_json_loader
+from .utils import xlm_tokenizer
+
+
+def random_mask(shape, ratio, device):
+    return (torch.rand(shape, device=device) < ratio)
+
+
+def get_image_loader(urls, batch_size, num_workers):
+    transform = torchvision.transforms.Compose([
+        torchvision.transforms.Resize(384, interpolation=3, antialias=True),
+        torchvision.transforms.CenterCrop((384, 384)),
+        torchvision.transforms.ToTensor(),
+    ])
+
+    def preprocess(img):
+        return transform(img.convert("RGB"))
+
+    dataset = (
+        wds.WebDataset(urls)
+        .decode("pil")
+        .to_tuple("jpg;png")
+        .map(preprocess)
+    )
+    return DataLoader(dataset.batched(batch_size), num_workers=num_workers)
+
+
+def get_text_loader(urls, tokenizer, batch_size, num_workers):
+    def preprocess(txt):
+        tokens, pad = xlm_tokenizer(txt.strip(), tokenizer)
+        return torch.tensor(tokens), torch.tensor(pad, dtype=torch.bool)
+
+    dataset = wds.WebDataset(urls).to_tuple("txt").map(lambda x: preprocess(x[0]))
+    return DataLoader(dataset.batched(batch_size), num_workers=num_workers)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="MUSK pretraining (multi GPU)")
+    p.add_argument("--json-data", type=str, help="Path to JSON lines dataset")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch-size", type=int, default=64)
+    p.add_argument("--lr", type=float, default=3e-4)
+    p.add_argument("--mask-ratio", type=float, default=0.15)
+    p.add_argument("--output", type=str, default="musk.pt")
+    p.add_argument("--num-workers", type=int, default=4)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    ddp = DistributedDataParallelKwargs(find_unused_parameters=True)
+    accelerator = Accelerator(kwargs_handlers=[ddp])
+
+    tokenizer_path = Path(__file__).resolve().parent / "models" / "tokenizer.spm"
+    tokenizer = XLMRobertaTokenizer(str(tokenizer_path))
+    mask_token_id = tokenizer.convert_tokens_to_ids("<mask>")
+
+    image_loader, val_image_loader = get_json_loaders(
+        args.json_data,
+        mode="image",
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        tokenizer=None,
+    )
+    text_loader, val_text_loader = get_json_loaders(
+        args.json_data,
+        mode="text",
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        tokenizer=tokenizer,
+    )
+
+    model = create_model("musk_large_patch16_384")
+    embed_dim = model.beit3.args.encoder_embed_dim
+    patch_size = model.beit3.args.patch_size
+    img_decoder = torch.nn.Linear(embed_dim, 3 * patch_size * patch_size)
+    txt_decoder = torch.nn.Linear(embed_dim, len(tokenizer))
+
+    optimizer = torch.optim.AdamW(
+        itertools.chain(model.parameters(), img_decoder.parameters(), txt_decoder.parameters()),
+        lr=args.lr,
+    )
+
+    components = accelerator.prepare(model, img_decoder, txt_decoder, optimizer, image_loader, text_loader)
+    model, img_decoder, txt_decoder, optimizer, image_loader, text_loader = components
+    val_image_loader = accelerator.prepare(val_image_loader)
+    val_text_loader = accelerator.prepare(val_text_loader)
+
+    mse_loss = torch.nn.MSELoss()
+    ce_loss = torch.nn.CrossEntropyLoss()
+
+    for epoch in range(args.epochs):
+        model.train()
+        mim_total = 0.0
+        mlm_total = 0.0
+        num_batches = 0
+        for images, (tokens, padding) in zip(image_loader, text_loader):
+            optimizer.zero_grad()
+            B, _, H, W = images.shape
+            num_patches = (H // patch_size) * (W // patch_size)
+            mask_img = random_mask((B, num_patches), args.mask_ratio, images.device)
+            _, _, img_seq, _ = model(
+                image=images,
+                vision_mask=mask_img,
+                with_head=False,
+                out_norm=False,
+                return_global=False,
+                return_seq=True,
+            )
+            patches = F.unfold(images, kernel_size=patch_size, stride=patch_size).transpose(1, 2)
+            target = patches[mask_img]
+            pred = img_decoder(img_seq[mask_img])
+            loss_img = mse_loss(pred, target)
+
+            tokens = tokens.to(images.device)
+            padding = padding.to(images.device)
+            mask_txt = random_mask(tokens.shape, args.mask_ratio, tokens.device) & (~padding)
+            inp_tokens = tokens.clone()
+            inp_tokens[mask_txt] = mask_token_id
+            _, _, _, txt_seq = model(
+                text_description=inp_tokens,
+                padding_mask=padding,
+                with_head=False,
+                out_norm=False,
+                return_global=False,
+                return_seq=True,
+            )
+            pred_txt = txt_decoder(txt_seq[mask_txt])
+            loss_txt = ce_loss(pred_txt, tokens[mask_txt])
+
+            loss = loss_img + loss_txt
+            accelerator.backward(loss)
+            optimizer.step()
+
+            mim_total += loss_img.item()
+            mlm_total += loss_txt.item()
+            num_batches += 1
+
+        mim_avg = accelerator.reduce(torch.tensor(mim_total, device=accelerator.device), reduction="sum")
+        mlm_avg = accelerator.reduce(torch.tensor(mlm_total, device=accelerator.device), reduction="sum")
+        denom = accelerator.reduce(torch.tensor(num_batches, device=accelerator.device), reduction="sum")
+        mim_avg = (mim_avg / denom).item()
+        mlm_avg = (mlm_avg / denom).item()
+
+        accelerator.print(f"Epoch {epoch + 1}: MIM={mim_avg:.4f} MLM={mlm_avg:.4f}")
+
+        # validation
+        val_mim = 0.0
+        val_mlm = 0.0
+        val_batches = 0
+        model.eval()
+        for images, (tokens, padding) in zip(val_image_loader, val_text_loader):
+            with torch.no_grad():
+                B, _, H, W = images.shape
+                num_patches = (H // patch_size) * (W // patch_size)
+                mask_img = random_mask((B, num_patches), args.mask_ratio, images.device)
+                _, _, img_seq, _ = model(
+                    image=images,
+                    vision_mask=mask_img,
+                    with_head=False,
+                    out_norm=False,
+                    return_global=False,
+                    return_seq=True,
+                )
+                patches = F.unfold(images, kernel_size=patch_size, stride=patch_size).transpose(1, 2)
+                target = patches[mask_img]
+                pred = img_decoder(img_seq[mask_img])
+                loss_img = mse_loss(pred, target)
+
+                tokens = tokens.to(images.device)
+                padding = padding.to(images.device)
+                mask_txt = random_mask(tokens.shape, args.mask_ratio, tokens.device) & (~padding)
+                inp_tokens = tokens.clone()
+                inp_tokens[mask_txt] = mask_token_id
+                _, _, _, txt_seq = model(
+                    text_description=inp_tokens,
+                    padding_mask=padding,
+                    with_head=False,
+                    out_norm=False,
+                    return_global=False,
+                    return_seq=True,
+                )
+                pred_txt = txt_decoder(txt_seq[mask_txt])
+                loss_txt = ce_loss(pred_txt, tokens[mask_txt])
+
+                val_mim += loss_img.item()
+                val_mlm += loss_txt.item()
+                val_batches += 1
+
+        vm = accelerator.reduce(torch.tensor(val_mim, device=accelerator.device), reduction="sum")
+        vl = accelerator.reduce(torch.tensor(val_mlm, device=accelerator.device), reduction="sum")
+        vd = accelerator.reduce(torch.tensor(val_batches, device=accelerator.device), reduction="sum")
+        vm = (vm / vd).item()
+        vl = (vl / vd).item()
+        accelerator.print(
+            f"Epoch {epoch + 1}: Val_MIM={vm:.4f} Val_MLM={vl:.4f}")
+
+    if accelerator.is_main_process:
+        base_model = accelerator.unwrap_model(model)
+        accelerator.print(f"Saving model to {args.output}")
+        torch.save(base_model.state_dict(), args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `mma_stage2.py` implementing MMA stage-two pretraining with contrastive and MLM losses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68485bc278d8832793278bbddc4a9e9d