### PR TITLE
Add domain inference utility and tests

### DIFF
--- a/musk/json_dataset.py
+++ b/musk/json_dataset.py
@@ -1,12 +1,15 @@
 """Dataset utilities for loading image and text samples from a JSON file.
 
-Each line in the JSON file should be an object with two keys:
-```
-{"image": "/path/to/image.jpg", "text": "free form caption"}
-```
+Each line in the JSON file should be an object with two keys::
+
+    {"image": "/path/to/image.jpg", "text": "free form caption"}
 
 Use ``mode="image"`` to iterate over images only, ``mode="text"`` for text
 only, or ``mode="pair"`` to return ``(image, text)`` tuples.
+
+``_infer_domain`` provides a tiny heuristic for categorising captions by
+domain. It returns ``0`` for captions mentioning ``"x-ray"``, ``1`` for
+``"pathology"`` and ``2`` for ``"endoscopy"``.
 """
 
 import json
@@ -30,6 +33,28 @@ def _load_json_lines(path: str) -> List[dict]:
                 continue
             items.append(json.loads(line))
     return items
+
+
+def _infer_domain(text: str) -> int:
+    """Heuristically map a caption to a domain label.
+
+    The mapping is:
+        0 - ``"x-ray"``
+        1 - ``"pathology"``
+        2 - ``"endoscopy"``
+
+    The check is case-insensitive and falls back to ``0`` when none of the
+    keywords are present.
+    """
+
+    t = text.lower()
+    if "x-ray" in t or "xray" in t:
+        return 0
+    if "pathology" in t:
+        return 1
+    if "endoscopy" in t:
+        return 2
+    return 0
 
 
 class ImageTextJsonDataset(Dataset):

--- a/tests/test_json_dataset.py
+++ b/tests/test_json_dataset.py
@@ -1,0 +1,16 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+source = (ROOT / "musk" / "json_dataset.py").read_text()
+module = ast.parse(source)
+fn_source = next(ast.get_source_segment(source, node) for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "_infer_domain")
+ns: dict = {}
+exec(fn_source, ns)
+_infer_domain = ns["_infer_domain"]
+
+
+def test_infer_domain():
+    assert _infer_domain("chest x-ray image") == 0
+    assert _infer_domain("histopathology slide") == 1
+    assert _infer_domain("endoscopy view") == 2


### PR DESCRIPTION
## Summary
- map domain keywords "x-ray", "pathology" and "endoscopy" to labels in `_infer_domain`
- document domain mapping in `json_dataset.py`
- test domain inference logic

## Testing
- `black musk/json_dataset.py tests/test_json_dataset.py`
- `pytest -q`
- `python musk/contrastive_pretrain.py --num-experts 3 --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68635b25dae8832786e0330c2f75e962