### PR TITLE
Add domain gating support

### DIFF
--- a/musk/torchscale/architecture/encoder.py
+++ b/musk/torchscale/architecture/encoder.py
@@ -20,6 +20,7 @@ from ..component.multiway_network import MultiwayWrapper, set_split_position
 from ..component.relative_position_bias import RelativePositionBias
 from ..component.xmoe.moe_layer import MOELayer
 from ..component.xmoe.routing import Top1Gate, Top2Gate
+from ..component.xmoe import DomainGate
 
 
 class EncoderLayer(nn.Module):
@@ -71,6 +72,8 @@ class EncoderLayer(nn.Module):
                     args.moe_eval_capacity_token_fraction,
                     use_xmoe=args.use_xmoe,
                 )
+            self.default_gate = gate
+            self.domain_gate = DomainGate(args.moe_expert_count)
             experts = make_experts(args, self.embed_dim, self.ffn_dim)
             self.moe_layer = MOELayer(gate, experts, args)
         self.final_layer_norm = MultiwayWrapper(args, LayerNorm(self.embed_dim, eps=args.layernorm_eps))
@@ -113,7 +116,7 @@ class EncoderLayer(nn.Module):
     def residual_connection(self, x, residual):
         return residual * self.alpha + x
 
-    def forward(self, x, encoder_padding_mask, attn_mask=None, rel_pos=None, multiway_split_position=None, incremental_state=None):
+    def forward(self, x, encoder_padding_mask, attn_mask=None, rel_pos=None, multiway_split_position=None, incremental_state=None, domain_ids=None):
         if multiway_split_position is not None:
             assert self.args.multiway
             self.apply(set_split_position(multiway_split_position))
@@ -150,7 +153,11 @@ class EncoderLayer(nn.Module):
             l_aux = None
         else:
             x = x.transpose(0, 1)
-            x, l_aux = self.moe_layer(x)
+            if domain_ids is not None:
+                self.moe_layer.gate = self.domain_gate
+            else:
+                self.moe_layer.gate = self.default_gate
+            x, l_aux = self.moe_layer(x, domain_ids=domain_ids)
             x = x.transpose(0, 1)
 
         if self.drop_path is not None:
@@ -335,6 +342,7 @@ class Encoder(nn.Module):
         features_only=False,
         incremental_state=None,
         positions=None,
+        domain_labels=None,
         **kwargs
     ):
         assert src_tokens is not None or token_embeddings is not None
@@ -370,6 +378,9 @@ class Encoder(nn.Module):
 
         # incremental_state is not None during inference if we use the bidirectional encoder as a generator as in s2s-ft (https://arxiv.org/abs/2110.13640)
         l_aux = []
+        flat_domain = None
+        if domain_labels is not None:
+            flat_domain = domain_labels.view(-1, 1).expand(-1, x.size(1)).reshape(-1)
         for idx, layer in enumerate(self.layers):
             x, l_aux_i = layer(
                 x,
@@ -378,6 +389,7 @@ class Encoder(nn.Module):
                 rel_pos=rel_pos_bias,
                 multiway_split_position=multiway_split_position,
                 incremental_state=incremental_state[idx] if incremental_state is not None else None,
+                domain_ids=flat_domain,
             )
             if return_all_hiddens:
                 assert encoder_states is not None

--- a/musk/torchscale/component/xmoe/__init__.py
+++ b/musk/torchscale/component/xmoe/__init__.py
@@ -1,2 +1,6 @@
 # Copyright (c) 2022 Microsoft
 # Licensed under The MIT License [see LICENSE for details]
+
+from .domain_gate import DomainGate
+
+__all__ = ["DomainGate"]

--- a/musk/torchscale/component/xmoe/domain_gate.py
+++ b/musk/torchscale/component/xmoe/domain_gate.py
@@ -1,0 +1,37 @@
+import math
+from typing import Optional, Tuple, Dict
+
+import torch
+from torch import Tensor
+
+from .routing import one_hot
+from .moe_layer import fused_cumsum_sub_one
+
+
+class DomainGate(torch.nn.Module):
+    """Gate routing tokens to a fixed expert based on domain labels."""
+
+    def __init__(self, num_experts: int) -> None:
+        super().__init__()
+        self.num_experts = num_experts
+
+    def forward(self, input: Tensor, mask: Optional[Tensor] = None, domain_ids: Optional[Tensor] = None) -> Tuple[Tensor, Tensor, Tensor, Dict]:
+        assert domain_ids is not None, "Domain IDs required"
+        num_tokens = input.size(0)
+        device = input.device
+        domain_ids = domain_ids.to(device).view(-1, 1)
+        mask1 = one_hot(domain_ids, self.num_experts)
+        if mask is not None:
+            mask1 = mask1 * (~mask).unsqueeze(-1).to(mask1.dtype)
+        locations1 = fused_cumsum_sub_one(mask1)
+        capacity = math.ceil(num_tokens / self.num_experts)
+        mask1 = mask1 * (locations1 < capacity)
+        locations1_s = torch.sum(locations1 * mask1, dim=1)
+        gates1_s = torch.ones(num_tokens, device=device)
+        gates1 = gates1_s.unsqueeze(-1) * mask1
+        locations1_sc = one_hot(locations1_s, num_classes=capacity, unsqueeze_indices=True)
+        combine1_sec = torch.bmm(gates1.unsqueeze(-1), locations1_sc.to(gates1.dtype).unsqueeze(1))
+        dispatch_mask = combine1_sec.bool()
+        l_aux = torch.tensor(0.0, device=device)
+        metadata: Dict = {}
+        return l_aux, combine1_sec, dispatch_mask, metadata

--- a/musk/torchscale/component/xmoe/moe_layer.py
+++ b/musk/torchscale/component/xmoe/moe_layer.py
@@ -204,7 +204,7 @@ class MOELayer(Base):
 
         if has_tutel:
             l_aux, self.metadata, C, E, indices_, locations_, gates_ = self.gate(
-                reshaped_input, reshaped_input_padding_mask
+                reshaped_input, reshaped_input_padding_mask, **kwargs
             )
             S, M = reshaped_input.size(0), reshaped_input.size(1)
 
@@ -216,7 +216,7 @@ class MOELayer(Base):
             dispatched_input = self._tutel_dispatcher.encode(reshaped_input)
         else:
             l_aux, combine_weights, dispatch_mask, self.metadata = self.gate(
-                reshaped_input, reshaped_input_padding_mask
+                reshaped_input, reshaped_input_padding_mask, **kwargs
             )
 
             dispatch_mask = dispatch_mask.to(input.dtype).permute(

--- a/musk/torchscale/model/BEiT3.py
+++ b/musk/torchscale/model/BEiT3.py
@@ -54,6 +54,7 @@ class BEiT3(nn.Module):
         vision_masked_position=None,
         incremental_state=None,
         positions=None,
+        domain_labels=None,
     ):
         assert textual_tokens is not None or visual_tokens is not None
 
@@ -90,6 +91,7 @@ class BEiT3(nn.Module):
             multiway_split_position=multiway_split_position,
             incremental_state=incremental_state,
             positions=positions,
+            domain_labels=domain_labels,
         )
         encoder_out["multiway_split_position"] = multiway_split_position
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,23 @@
+import json
+import tempfile
+from pathlib import Path
+from PIL import Image
+import torch
+
+from musk.json_dataset import ImageTextJsonDataset
+
+
+def test_domain_label_image_mode():
+    with tempfile.TemporaryDirectory() as tmp:
+        img_path = Path(tmp) / "a" / "img.jpg"
+        img_path.parent.mkdir()
+        Image.new("RGB", (384, 384)).save(img_path)
+        data = [{"image": str(img_path), "text": "t", "domain": 1}]
+        json_file = Path(tmp) / "data.jsonl"
+        with open(json_file, "w") as f:
+            for item in data:
+                f.write(json.dumps(item) + "\n")
+        ds = ImageTextJsonDataset(str(json_file), mode="image")
+        img, domain = ds[0]
+        assert isinstance(img, torch.Tensor)
+        assert domain == 1

--- a/tests/test_domain_gate.py
+++ b/tests/test_domain_gate.py
@@ -1,0 +1,14 @@
+import torch
+from musk.torchscale.component.xmoe.domain_gate import DomainGate
+
+
+def test_domain_gate_routes():
+    gate = DomainGate(num_experts=2)
+    x = torch.randn(4, 8)
+    domains = torch.tensor([0, 0, 1, 1])
+    l_aux, combine, dispatch, _ = gate(x, domain_ids=domains)
+    # dispatch shape S,E,C; tokens routed to correct expert
+    expert0 = dispatch[:, 0, :].any(dim=1)
+    expert1 = dispatch[:, 1, :].any(dim=1)
+    assert expert0[:2].all() and not expert0[2:].any()
+    assert expert1[2:].all() and not expert1[:2].any()


### PR DESCRIPTION
## Summary
- extend JSON dataset to output domain labels
- expose `--num-experts` and `--moe-freq` options in training scripts
- add `DomainGate` and pass domain labels through the model
- handle auxiliary MoE losses in pretraining
- provide basic tests for dataset and domain gate

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_68636b92baa88327b946ba255e4bc498