### PR TITLE
Fix domain encoder device handling

### DIFF
--- a/musk/domain_encoders.py
+++ b/musk/domain_encoders.py
@@ -1,0 +1,29 @@
+import torch
+import torch.nn as nn
+
+class IdentityGate(nn.Module):
+    """Simple gate that returns the domain indices as-is."""
+
+    def forward(self, domains: torch.Tensor) -> torch.Tensor:
+        return domains
+
+
+class DomainEncoderManager(nn.Module):
+    """Manage multiple encoders based on domain indices."""
+
+    def __init__(self, encoders, gate=None):
+        super().__init__()
+        self.encoders = nn.ModuleList(encoders)
+        self.gate = gate or IdentityGate()
+
+    def forward(self, images: torch.Tensor, domains: torch.Tensor):
+        device = images.device
+        idxs = self.gate(domains).to(device)
+        batch_size = images.size(0)
+        feat_dim = self.encoders[0](images[:1]).shape[1]
+        outputs = torch.zeros(batch_size, feat_dim, device=device, dtype=images.dtype)
+        for i, encoder in enumerate(self.encoders):
+            mask = idxs == i
+            if mask.any():
+                outputs[mask] = encoder(images[mask])
+        return outputs

--- a/tests/test_domain_gate.py
+++ b/tests/test_domain_gate.py
@@ -1,0 +1,26 @@
+import torch
+import torch.nn as nn
+from musk.domain_encoders import DomainEncoderManager, IdentityGate
+
+class DummyEncoder(nn.Module):
+    def __init__(self, factor: float):
+        super().__init__()
+        self.factor = factor
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # simple feature: mean over spatial dims scaled by factor
+        x = x.mean(dim=(2, 3)) * self.factor
+        return x
+
+def test_domain_encoder_manager_device():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    images = torch.randn(4, 3, 8, 8).to(device)
+    domains = torch.tensor([0, 1, 0, 1])  # remains on CPU
+
+    enc1 = DummyEncoder(1.0)
+    enc2 = DummyEncoder(2.0)
+    manager = DomainEncoderManager([enc1, enc2], gate=IdentityGate())
+
+    out = manager(images, domains)
+    assert out.device == device
+    assert out.shape[0] == images.shape[0]


### PR DESCRIPTION
## Summary
- add a simple DomainEncoderManager with IdentityGate
- ensure domain indices are moved to the same device as images
- test DomainEncoderManager on CPU or CUDA

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_686dfdc4dc24832796cbb6434aae474b