### PR TITLE
Add clustering option for UMAP visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,17 @@ and the script prints contrastive and MLM losses for both splits each epoch.
 `musk/models/tokenizer.spm`. Pass `--wandb-project <name>` to log
 training metrics to Weights & Biases.
 Specify `--wandb-project <name>` to log these metrics to Weights & Biases.
+
+## UMAP visualization
+
+Use `musk.umap_json` to visualize embeddings stored in a JSON lines file. Each line
+should contain an `embedding` array and may include a `domain` label.
+With `--cluster-domains <k>` the script clusters the embeddings using
+KMeans before plotting and reports the V-measure when true domain labels are
+present.
+
+Example:
+
+```shell
+python -m musk.umap_json data.jsonl --cluster-domains 3 --output umap.png
+```

--- a/musk/umap_json.py
+++ b/musk/umap_json.py
@@ -1,0 +1,145 @@
+# --------------------------------------------------------
+# MUSK: A Vision-Language Foundation Model for Precision Oncology
+# Published in Nature, 2025
+# GitHub Repository: https://github.com/lilab-stanford/MUSK
+# --------------------------------------------------------
+"""UMAP visualization utilities for JSON embeddings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from typing import List, Optional, Tuple
+
+
+def _load_json_lines(path: str) -> List[dict]:
+    items: List[dict] = []
+    with open(path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            items.append(json.loads(line))
+    return items
+
+
+def collect_embeddings(json_file: str) -> Tuple[List[List[float]], Optional[List[str]]]:
+    """Return embeddings and optional domain labels from a JSON lines file."""
+    items = _load_json_lines(json_file)
+    embeddings: List[List[float]] = []
+    domains: List[str] = []
+    for it in items:
+        if "embedding" not in it:
+            raise ValueError("Each JSON item must include an 'embedding' field")
+        embeddings.append([float(x) for x in it["embedding"]])
+        if "domain" in it:
+            domains.append(it["domain"])
+    labels = domains if domains else None
+    return embeddings, labels
+
+
+def _dist_sq(a: List[float], b: List[float]) -> float:
+    return sum((x - y) ** 2 for x, y in zip(a, b))
+
+
+def kmeans_cluster(x: List[List[float]], k: int, n_iter: int = 20, seed: int = 0) -> List[int]:
+    """Simple k-means clustering implemented without external dependencies."""
+    random.seed(seed)
+    centroids = [x[i][:] for i in random.sample(range(len(x)), k)]
+    for _ in range(n_iter):
+        labels = [min(range(k), key=lambda j: _dist_sq(pt, centroids[j])) for pt in x]
+        new_centroids = [centroids[j][:] for j in range(k)]
+        for j in range(k):
+            pts = [p for p, lab in zip(x, labels) if lab == j]
+            if pts:
+                dim = len(pts[0])
+                new_centroids[j] = [sum(p[d] for p in pts) / len(pts) for d in range(dim)]
+        if all(all(abs(a - b) < 1e-6 for a, b in zip(c_old, c_new)) for c_old, c_new in zip(centroids, new_centroids)):
+            centroids = new_centroids
+            break
+        centroids = new_centroids
+    return labels
+
+
+def _entropy(labels: List) -> float:
+    counts = {}
+    for l in labels:
+        counts[l] = counts.get(l, 0) + 1
+    total = len(labels)
+    return -sum((c / total) * math.log(c / total + 1e-10) for c in counts.values())
+
+
+def v_measure(labels_true: List, labels_pred: List[int]) -> float:
+    """Compute V-measure between two clusterings."""
+    n = len(labels_true)
+    h_c = _entropy(labels_true)
+    h_k = _entropy(labels_pred)
+
+    h_c_k = 0.0
+    for k_val in set(labels_pred):
+        idxs = [i for i, l in enumerate(labels_pred) if l == k_val]
+        sub = [labels_true[i] for i in idxs]
+        h_c_k += len(idxs) / n * _entropy(sub)
+
+    h_k_c = 0.0
+    for c_val in set(labels_true):
+        idxs = [i for i, l in enumerate(labels_true) if l == c_val]
+        sub = [labels_pred[i] for i in idxs]
+        h_k_c += len(idxs) / n * _entropy(sub)
+
+    homogeneity = 1.0 if h_c == 0 else 1 - h_c_k / h_c
+    completeness = 1.0 if h_k == 0 else 1 - h_k_c / h_k
+    denom = homogeneity + completeness
+    return 0.0 if denom == 0 else 2 * homogeneity * completeness / denom
+
+
+def plot_umap(embeddings: List[List[float]], labels: Optional[list] = None, out_file: str = "umap.png") -> None:
+    """Generate a UMAP scatter plot."""
+    import umap
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    reducer = umap.UMAP()
+    pts = reducer.fit_transform(np.array(embeddings))
+    plt.figure()
+    if labels is None:
+        plt.scatter(pts[:, 0], pts[:, 1], s=5)
+    else:
+        labels = np.asarray(labels)
+        for l in np.unique(labels):
+            idx = labels == l
+            plt.scatter(pts[idx, 0], pts[idx, 1], s=5, label=str(l))
+        plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_file)
+
+
+def get_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="UMAP visualization for JSON embeddings")
+    p.add_argument("json_file", type=str, help="JSON lines file with embeddings")
+    p.add_argument("--output", type=str, default="umap.png", help="Output image path")
+    p.add_argument("--cluster-domains", type=int, metavar="k", default=None, help="Cluster embeddings into k groups")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = get_args()
+    embeddings, domains = collect_embeddings(args.json_file)
+    colour_labels = None
+    if args.cluster_domains is not None:
+        colour_labels = kmeans_cluster(embeddings, args.cluster_domains)
+        if domains is not None:
+            score = v_measure(domains, colour_labels)
+            print(f"V-measure: {score:.3f}")
+    elif domains is not None:
+        colour_labels = domains
+    try:
+        plot_umap(embeddings, colour_labels, args.output)
+    except ImportError as e:
+        raise RuntimeError("Plotting requires 'umap-learn' and 'matplotlib'") from e
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_umap_json.py
+++ b/tests/test_umap_json.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from musk.umap_json import collect_embeddings, kmeans_cluster
+
+
+def make_dummy_json(tmp_path: Path, n: int = 4) -> Path:
+    path = tmp_path / "data.jsonl"
+    with open(path, "w") as f:
+        for i in range(n):
+            item = {
+                "embedding": [float(i), float(i + 1)],
+                "domain": "a" if i % 2 == 0 else "b",
+            }
+            f.write(json.dumps(item) + "\n")
+    return path
+
+
+def test_cluster_labels(tmp_path: Path):
+    json_path = make_dummy_json(tmp_path, n=6)
+    emb, _ = collect_embeddings(json_path)
+    labels = kmeans_cluster(emb, 2)
+    assert len(labels) == 6


### PR DESCRIPTION
## Summary
- implement `musk.umap_json` providing UMAP visualisation utilities
- add `--cluster-domains` argument to optionally run k-means clustering
- document the feature in the README
- add regression test for clustering functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686f2c591f048327b396cd89ca15e430