### PR TITLE
Handle MRI encoder channels in DomainEncoderManager

### DIFF
--- a/musk/domain_encoders.py
+++ b/musk/domain_encoders.py
@@ -1,0 +1,53 @@
+# --------------------------------------------------------
+# MUSK: A Vision-Language Foundation Model for Precision Oncology
+# Published in Nature, 2025
+# GitHub Repository: https://github.com/lilab-stanford/MUSK
+# Copyright (c) 2025 Stanford University
+# Licensed under the CC-BY-NC-ND 4.0 License (https://creativecommons.org/licenses/by-nc-nd/4.0/)
+# Please see LICENSE for additional details.
+# --------------------------------------------------------
+"""Domain-specific encoder utilities."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+from types import SimpleNamespace
+
+import torch
+
+
+class DomainEncoderManager:
+    """Simple manager for domain-specific encoders."""
+
+    def __init__(self, loaders: Dict[str, Callable[[], Callable[[torch.Tensor], tuple]]]):
+        self.loaders = loaders
+        self.encoders: Dict[str, Callable[[torch.Tensor], tuple]] = {}
+
+    def get_encoder(self, domain: str) -> Callable[[torch.Tensor], tuple]:
+        if domain not in self.encoders:
+            self.encoders[domain] = self.loaders[domain]()
+        return self.encoders[domain]
+
+    def encode(self, domain: str, images: torch.Tensor) -> tuple:
+        return self.get_encoder(domain)(images)
+
+    __call__ = encode
+
+
+def load_mri_encoder(autoencoder) -> Callable[[torch.Tensor], tuple]:
+    """Return a wrapper around ``AutoencoderKL`` for MRI images."""
+
+    in_channels = autoencoder.config.in_channels
+
+    def encode(images: torch.Tensor) -> tuple:
+        if images.shape[1] != in_channels:
+            if images.shape[1] > in_channels:
+                images = images[:, :in_channels]
+            else:
+                repeat = (in_channels + images.shape[1] - 1) // images.shape[1]
+                images = images.repeat(1, repeat, 1, 1)[:, :in_channels]
+        latents = autoencoder.encode(images).latent_dist.sample()
+        pooled = latents.mean(dim=(-2, -1))
+        return (pooled,)
+
+    return encode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+import importlib.util
+from pathlib import Path
+
+stub_path = Path(__file__).parent / 'torch_stub.py'
+spec = importlib.util.spec_from_file_location('torch_stub', stub_path)
+torch_stub = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(torch_stub)
+sys.modules.setdefault('torch', torch_stub)

--- a/tests/test_domain_encoders.py
+++ b/tests/test_domain_encoders.py
@@ -1,0 +1,24 @@
+import torch
+from types import SimpleNamespace
+from musk.domain_encoders import load_mri_encoder, DomainEncoderManager
+
+
+class DummyAutoencoder:
+    def __init__(self, in_channels=2):
+        self.config = SimpleNamespace(in_channels=in_channels)
+
+    class _LatentDist:
+        def __init__(self, x):
+            self.x = x
+        def sample(self):
+            return self.x
+
+    def encode(self, x):
+        return SimpleNamespace(latent_dist=self._LatentDist(x))
+
+
+def test_mri_wrapper_accepts_three_channel_input():
+    ae = DummyAutoencoder(in_channels=2)
+    manager = DomainEncoderManager({"mri": lambda: load_mri_encoder(ae)})
+    img = torch.randn(1, 3, 64, 64)
+    manager.encode("mri", img)

--- a/tests/torch_stub.py
+++ b/tests/torch_stub.py
@@ -1,0 +1,42 @@
+class Tensor:
+    def __init__(self, shape):
+        self._shape = tuple(shape)
+
+    @property
+    def shape(self):
+        return self._shape
+
+    def mean(self, dim=None):
+        if dim is None:
+            self._shape = (1,)
+        else:
+            if isinstance(dim, int):
+                dim = (dim,)
+            dims = sorted([(d if d >= 0 else len(self._shape) + d) for d in dim], reverse=True)
+            shape = list(self._shape)
+            for d in dims:
+                shape.pop(d)
+            if not shape:
+                shape = (1,)
+            self._shape = tuple(shape)
+        return self
+
+    def repeat(self, *reps):
+        if len(reps) == 1 and isinstance(reps[0], tuple):
+            reps = reps[0]
+        self._shape = tuple(s * r for s, r in zip(self._shape, reps))
+        return self
+
+    def __getitem__(self, item):
+        if isinstance(item, tuple) and isinstance(item[1], slice):
+            stop = item[1].stop if item[1].stop is not None else self._shape[1]
+            start = item[1].start or 0
+            c = stop - start
+            shape = list(self._shape)
+            shape[1] = c
+            self._shape = tuple(shape)
+        return self
+
+
+def randn(*shape):
+    return Tensor(shape)


### PR DESCRIPTION
## Summary
- add `musk/domain_encoders.py` with a simple `DomainEncoderManager`
- implement `load_mri_encoder` that wraps an `AutoencoderKL` style module and pools latents
- stub `torch` with a minimal implementation so tests don't require the real package
- test that `DomainEncoderManager` handles 3‑channel MRI images for a two‑channel autoencoder

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686f47c9676883278490ad62146ea888